### PR TITLE
Disable one linter for Go 1.26

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.golangci.yml
+++ b/provider-ci/internal/pkg/templates/base/.golangci.yml
@@ -23,6 +23,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - revive
+        path: pkg/version/
+        text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:
     - gci

--- a/provider-ci/test-providers/acme/.golangci.yml
+++ b/provider-ci/test-providers/acme/.golangci.yml
@@ -23,6 +23,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - revive
+        path: pkg/version/
+        text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:
     - gci

--- a/provider-ci/test-providers/aws/.golangci.yml
+++ b/provider-ci/test-providers/aws/.golangci.yml
@@ -23,6 +23,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - revive
+        path: pkg/version/
+        text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:
     - gci

--- a/provider-ci/test-providers/cloudflare/.golangci.yml
+++ b/provider-ci/test-providers/cloudflare/.golangci.yml
@@ -23,6 +23,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - revive
+        path: pkg/version/
+        text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:
     - gci

--- a/provider-ci/test-providers/docker/.golangci.yml
+++ b/provider-ci/test-providers/docker/.golangci.yml
@@ -23,6 +23,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - revive
+        path: pkg/version/
+        text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:
     - gci

--- a/provider-ci/test-providers/eks/.golangci.yml
+++ b/provider-ci/test-providers/eks/.golangci.yml
@@ -23,6 +23,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - revive
+        path: pkg/version/
+        text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:
     - gci

--- a/provider-ci/test-providers/terraform-module/.golangci.yml
+++ b/provider-ci/test-providers/terraform-module/.golangci.yml
@@ -23,6 +23,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - revive
+        path: pkg/version/
+        text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:
     - gci

--- a/provider-ci/test-providers/xyz/.golangci.yml
+++ b/provider-ci/test-providers/xyz/.golangci.yml
@@ -23,6 +23,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - revive
+        path: pkg/version/
+        text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:
     - gci


### PR DESCRIPTION
Workaround for https://github.com/pulumi/ci-mgmt/issues/2100

Upstream change: https://github.com/pulumi/ci-mgmt/pull/2128/changes/b32800f0bfb3728554f35a3759f6db22e5eb5836#diff-2ceefb1375eac996fddd2d6f6a4545b2543374a9a681df7d54ec84c08c90076d