### PR TITLE
feat: allow custom GitHub App credentials

### DIFF
--- a/provider-ci/internal/pkg/github_app_test.go
+++ b/provider-ci/internal/pkg/github_app_test.go
@@ -1,0 +1,84 @@
+package pkg
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGitHubAppCredentials_renderCustomExpressions_whenConfigured(t *testing.T) {
+	// Given
+	configPath := filepath.Join(t.TempDir(), ".ci-mgmt.yaml")
+	configContent := `github-app:
+  enabled: true
+  id: ${{ secrets.RELEASE_APP_ID }}
+  private-key: ${{ secrets.RELEASE_APP_PEM }}
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	config, err := LoadLocalConfig(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	tmpl, err := parseTemplate(templateFS, "templates/base/.github/workflows/test.yml")
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	// When
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, templateContext{Config: config}); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	content := rendered.String()
+
+	// Then
+	for _, want := range []string{
+		"app-id: ${{ secrets.RELEASE_APP_ID }}",
+		"private-key: ${{ secrets.RELEASE_APP_PEM }}",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("expected rendered workflow to contain %q, got:\n%s", want, content)
+		}
+	}
+	for _, unwanted := range []string{
+		"PULUMI_PROVIDER_AUTOMATION_APP_ID",
+		"PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY",
+	} {
+		if strings.Contains(content, unwanted) {
+			t.Fatalf("expected rendered workflow not to contain %q, got:\n%s", unwanted, content)
+		}
+	}
+}
+
+func TestDefaultGitHubAppCredentials_matchExistingWorkflowSecretNames(t *testing.T) {
+	// Given
+	config, err := loadDefaultConfig()
+	if err != nil {
+		t.Fatalf("load default config: %v", err)
+	}
+	tmpl, err := parseTemplate(templateFS, "templates/base/.github/workflows/test.yml")
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	// When
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, templateContext{Config: config}); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	content := rendered.String()
+
+	// Then
+	for _, want := range []string{
+		"app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}",
+		"private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("expected rendered workflow to contain %q, got:\n%s", want, content)
+		}
+	}
+}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -58,8 +58,8 @@ jobs:
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-auth
         with:
-          app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+          app-id: #{{ .Config.GitHubApp.ID }}#
+          private-key: #{{ .Config.GitHubApp.PrivateKey }}#
           owner: ${{ github.repository_owner }}
 #{{- end }}#
       # Without ldid cross-compiling Node binaries on a Linux worker intended to work on darwin-arm64 fails to sign the

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -48,8 +48,8 @@ jobs:
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-auth
         with:
-          app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+          app-id: #{{ .Config.GitHubApp.ID }}#
+          private-key: #{{ .Config.GitHubApp.PrivateKey }}#
           owner: ${{ github.repository_owner }}
 #{{- end }}#
       - name: Cache examples generation

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/license.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/license.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-auth
         with:
-          app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+          app-id: #{{ .Config.GitHubApp.ID }}#
+          private-key: #{{ .Config.GitHubApp.PrivateKey }}#
           owner: ${{ github.repository_owner }}
 #{{- end }}#
       - name: Install mise

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/lint.yml
@@ -36,8 +36,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Install mise

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -52,8 +52,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - uses: #{{ .Config.ActionVersions.ProviderVersionAction }}#

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
@@ -48,8 +48,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Install mise
@@ -153,8 +153,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Install mise
@@ -245,8 +245,8 @@ jobs:
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-auth
         with:
-          app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+          app-id: #{{ .Config.GitHubApp.ID }}#
+          private-key: #{{ .Config.GitHubApp.PrivateKey }}#
           owner: ${{ github.repository_owner }}
 #{{- end }}#
       - name: Dispatch Metadata build
@@ -282,8 +282,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Clean up release labels

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -45,8 +45,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Checkout p/examples

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
@@ -88,8 +88,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Install mise

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -56,8 +56,8 @@ jobs:
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-auth
         with:
-          app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+          app-id: #{{ .Config.GitHubApp.ID }}#
+          private-key: #{{ .Config.GitHubApp.PrivateKey }}#
           owner: ${{ github.repository_owner }}
 #{{- end }}#
       - name: Install mise

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -225,7 +225,7 @@ sdkModuleDir: "sdk"
 github-app:
   enabled: true
   id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-  private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_SECRET_KEY }}
+  private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
 
 # Version of mise to use
 mise-version: 2026.3.7

--- a/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
@@ -36,8 +36,8 @@ jobs:
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-auth
         with:
-          app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+          app-id: #{{ .Config.GitHubApp.ID }}#
+          private-key: #{{ .Config.GitHubApp.PrivateKey }}#
           owner: ${{ github.repository_owner }}
 #{{- end }}#
       - name: Configure AWS Credentials

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -203,8 +203,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -316,8 +316,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -454,8 +454,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -527,8 +527,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -33,8 +33,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -192,8 +192,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -278,8 +278,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -416,8 +416,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -489,8 +489,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -569,8 +569,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
     #{{- end }}#
     - id: version

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -193,8 +193,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -280,8 +280,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -418,8 +418,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -491,8 +491,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -571,8 +571,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -663,8 +663,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Install pulumictl

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -61,8 +61,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -271,8 +271,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version
@@ -410,8 +410,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - id: version

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/weekly-pulumi-update.yml
@@ -31,8 +31,8 @@ jobs:
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: app-auth
       with:
-        app-id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
-        private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        app-id: #{{ .Config.GitHubApp.ID }}#
+        private-key: #{{ .Config.GitHubApp.PrivateKey }}#
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Setup Tools


### PR DESCRIPTION
## Summary
- render GitHub App `app-id` and `private-key` from `.ci-mgmt.yaml` `github-app.id` and `github-app.private-key`
- preserve the existing default rendered secret names
- add focused tests for custom and default GitHub App credential rendering

## Verification
- `go test ./internal/pkg`
- `go test ./...`
- `go test -race ./...`
- generated external-bridged provider with custom `RELEASE_APP_ID` / `RELEASE_APP_PEM` and verified rendered workflow refs
- generated native provider with custom `RELEASE_APP_ID` / `RELEASE_APP_PEM` and verified rendered workflow refs
- `make test-providers`