### PR TITLE
fix(ci): honor configured publish secret aliases

### DIFF
--- a/provider-ci/internal/pkg/generate_test.go
+++ b/provider-ci/internal/pkg/generate_test.go
@@ -1,0 +1,50 @@
+package pkg
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGeneratePackage_publishUsesConfiguredEnvironmentAliases(t *testing.T) {
+	// Given
+	configPath := filepath.Join("..", "..", "test-providers", "eks", ".ci-mgmt.yaml")
+	config, err := LoadLocalConfig(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	config.Env["NPM_TOKEN"] = "${{ secrets.CUSTOM_NPM_TOKEN }}"
+	config.Env["NUGET_PUBLISH_KEY"] = "${{ secrets.CUSTOM_NUGET_KEY }}"
+	config.Env["PYPI_API_TOKEN"] = "${{ secrets.CUSTOM_PYPI_TOKEN }}"
+
+	outDir := t.TempDir()
+	if err := GeneratePackage(GenerateOpts{
+		RepositoryName: "example/pulumi-test",
+		OutDir:         outDir,
+		TemplateName:   "external-bridged-provider",
+		Config:         config,
+		SkipMigrations: true,
+	}); err != nil {
+		t.Fatalf("generate package: %v", err)
+	}
+
+	publishWorkflow, err := os.ReadFile(filepath.Join(outDir, ".github", "workflows", "publish.yml"))
+	if err != nil {
+		t.Fatalf("read publish workflow: %v", err)
+	}
+
+	// When
+	generated := string(publishWorkflow)
+
+	// Then
+	for _, expected := range []string{
+		"PYPI_PASSWORD: ${{ env.PYPI_API_TOKEN }}",
+		"NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}",
+		"NUGET_PUBLISH_KEY: ${{ env.NUGET_PUBLISH_KEY }}",
+	} {
+		if !strings.Contains(generated, expected) {
+			t.Errorf("generated publish workflow does not use configured environment alias %q", expected)
+		}
+	}
+}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
@@ -180,14 +180,14 @@ jobs:
         version: ${{ inputs.version }}
       env:
         PYPI_USERNAME: __token__
-        PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        PYPI_PASSWORD: ${{ env.PYPI_API_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
         SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+        NUGET_PUBLISH_KEY: ${{ env.NUGET_PUBLISH_KEY }}
     - name: Publish SDKs (except Java)
       if: inputs.skipJavaSdk == true
       uses: pulumi/pulumi-package-publisher@3ec1409d3e894142b9825c7859be8e57d362762a # v0.0.23
@@ -196,12 +196,12 @@ jobs:
         version: ${{ inputs.version }}
       env:
         PYPI_USERNAME: __token__
-        PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        PYPI_PASSWORD: ${{ env.PYPI_API_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
         SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-        NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+        NUGET_PUBLISH_KEY: ${{ env.NUGET_PUBLISH_KEY }}
     - name: Download Go SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -144,14 +144,14 @@ jobs:
         version: ${{ inputs.version }}
       env:
         PYPI_USERNAME: __token__
-        PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        PYPI_PASSWORD: ${{ env.PYPI_API_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
         SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+        NUGET_PUBLISH_KEY: ${{ env.NUGET_PUBLISH_KEY }}
     - name: Publish SDKs (except Java)
       if: inputs.skipJavaSdk == true
       uses: pulumi/pulumi-package-publisher@3ec1409d3e894142b9825c7859be8e57d362762a # v0.0.23
@@ -160,12 +160,12 @@ jobs:
         version: ${{ inputs.version }}
       env:
         PYPI_USERNAME: __token__
-        PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        PYPI_PASSWORD: ${{ env.PYPI_API_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
         SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-        NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+        NUGET_PUBLISH_KEY: ${{ env.NUGET_PUBLISH_KEY }}
     - name: Download Go SDK
       uses: ./.github/actions/download-sdk
       with:


### PR DESCRIPTION
## Summary

- use rendered workflow environment aliases for npm, PyPI, and NuGet publisher credentials
- preserve custom repository secret mappings after removal of the `esc-secrets` output bridge
- add a generation regression test and update the generated Acme fixture

## Verification

- `go test ./internal/pkg -run TestGeneratePackage_publishUsesConfiguredEnvironmentAliases -count=1`
- `go test ./...`
- `make test-provider/acme`
- `make lint`
- manual CLI generation with custom npm, PyPI, and NuGet secret names